### PR TITLE
configure.ac: Add AC_FUNC_STRERROR_R

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,6 +96,7 @@ DX_INIT_DOXYGEN([$PACKAGE_NAME],[doxygen.cfg])
 # Check some (almost) standard functionality is present that we require to run KAT.
 #AC_CHECK_HEADER_STDBOOL  # Commented this out because this was introduced after 2.63.
 AC_FUNC_ERROR_AT_LINE
+AC_FUNC_STRERROR_R
 AC_TYPE_INT16_T
 AC_TYPE_INT32_T
 AC_TYPE_INT64_T


### PR DESCRIPTION
For compatibility with jellyfish 1.1.11 which requires `HAVE_DECL_STRERROR_R` and `STRERROR_R_CHAR_P`.
See https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Particular-Functions.html
See also #2