### PR TITLE
Fixes #11 - broken optionality of input_3 in comp.cc

### DIFF
--- a/src/comp.cc
+++ b/src/comp.cc
@@ -785,7 +785,11 @@ int kat::Comp::main(int argc, char *argv[]) {
     // Glob input files
     vector<path> vecinput1 = InputHandler::globFiles(input1);
     vector<path> vecinput2 = InputHandler::globFiles(input2);
-    vector<path> vecinput3 = InputHandler::globFiles(input3);
+
+    vector<path> vecinput3;
+    if ( input3 != "" ){
+        vecinput3 = InputHandler::globFiles(input3);
+    }
     
     // Create the sequence coverage object
     Comp comp(vecinput1, vecinput2, vecinput3);


### PR DESCRIPTION
Leaving out the optional input_3 (the filter) was causing an error to be
thrown (#11).

To make it optional again added quick check to comp.cc to not run
call full input_handling on input_3 if it hasn't been provided.

This fix preserves the previously fixed error handling for missing/incorrect input_1/input_2
and correctly throws an error when input_3 is provided but is a non-existent file.

Unit tests (apart from swig bindings) pass on my build system 