### PR TITLE
Non canonical kmer counting

### DIFF
--- a/src/sect.cc
+++ b/src/sect.cc
@@ -702,7 +702,7 @@ int kat::Sect::main(int argc, char *argv[]) {
     sect.setCvgBins(cvg_bins);
     sect.setCvgLogscale(cvg_logscale);
     sect.setThreads(threads);
-    sect.setCanonical(non_canonical ? non_canonical : canonical ? canonical : true);        // Some crazy logic to default behaviour to canonical if not told otherwise
+    sect.setCanonical(non_canonical ? false : canonical ? canonical : true);        // Some crazy logic to default behaviour to canonical if not told otherwise
     sect.setMerLen(mer_len);
     sect.setHashSize(hash_size);
     sect.setNoCountStats(no_count_stats);


### PR DESCRIPTION
This logic always counts canonical kmers, there was no possible way to set the "setCanonical" variable to false.
Proposed fix to the logic of counting or not canonical kmers.