### PR TITLE
Py_Initialize() must be called before Py_GetPath()

### DIFF
--- a/lib/include/kat/pyhelper.hpp
+++ b/lib/include/kat/pyhelper.hpp
@@ -75,6 +75,8 @@ private:
             cout << " - Interpreter path: " << fpp << endl;
         }
 
+        Py_Initialize();
+
         vector<string> ppaths;
 
         wchar_t* wtppath2 = Py_GetPath();
@@ -97,7 +99,7 @@ private:
             cout << " - PYTHONPATH set"  << endl;
         }
 
-        Py_Initialize();
+
         if (this->verbose) {
             cout << "Python interpretter initialised" << endl << endl;
         }


### PR DESCRIPTION
According to the docs ( https://docs.python.org/3/c-api/init.html ), you must call `Py_Initialize()` before `Py_GetPath()`.

Because the code also called `Py_SetPath()` before `Py_Initialize()`, it meant that Python started with an empty `sys.prefix` and `sys.exec_prefix` (see documentation on `Py_SetPath`). As a consequence, the `site` module doesn't do it's magic and any `pth` files are ignored. This caused for me to the import of `scipy` to fail.

With this PR, we first call `Py_Initialize()`, then get the `Py_GetPath()` (with all `pth` files processed) and add the KAT path to it.