### PR TITLE
Update doc with exceptions to gzip input

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -8,7 +8,9 @@ Can KAT handle compressed sequence files?
 -----------------------------------------
 
 Yes, as of V2.4.0, KAT has native support for gzip decompression, so just treat
-gzipped files as regular uncompressed fastq or fasta files.
+gzipped files as regular uncompressed fastq or fasta files. The exceptions are
+``kat sect`` and ``kat filter`` which use a different fastq parser. For these
+modules, use process substitution as described below.
 
 If you wish to decompress other files such as bzip (or if you are using a pre V2.4.0 KAT), then
 this is supported via named pipes.  Anonymous named pipes (process substitution)


### PR DESCRIPTION
gzip input files not supported for sect and filter modules, no plans to
implement them according to issue #123
(https://github.com/TGAC/KAT/issues/123). Mention this here because
otherwise not documented.